### PR TITLE
fix(react-file-type-icons): Map onepart extension to onenote icon

### DIFF
--- a/packages/react-file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/react-file-type-icons/src/FileTypeIconMap.ts
@@ -355,7 +355,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   multiple: {},
   one: {
     // This is a partial OneNote page or section export. Not whole notebooks, see "onetoc"
-    extensions: ['one'],
+    extensions: ['one', 'onepart'],
   },
   onetoc: {
     // This is an entire OneNote notebook.


### PR DESCRIPTION
## Previous Behavior

```onepart``` extension is mapped to ```genericfile``` (fallback) as it is not present in ```FileTypeIconMap```.

## New Behavior

```onepart``` extension is now mapped to ```one``` extension.

## Related Issue(s)

- Fixes # https://github.com/microsoft/fluentui/issues/33316